### PR TITLE
Use node-version: '22' in setup-node steps

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha"]
+auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]

--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]
+auto_approve_usernames = ["tamalsaha", "1gtm", "1gtm-app[bot]"]

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install Hugo
         run: |

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -7,11 +7,11 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install Hugo
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 


### PR DESCRIPTION
Standardize Node.js version in setup-node steps to '22'.